### PR TITLE
feat(translator): show browser.wait() notifications when found in translated diff

### DIFF
--- a/apps/translator/app/translatorSlice.ts
+++ b/apps/translator/app/translatorSlice.ts
@@ -21,6 +21,7 @@ export type AvailableLanguages = 'Protractor'
 export interface INotifications {
   copied: boolean
   noTranslationsMade: boolean
+  browserWaitTranslated: boolean
 }
 export interface ITranslatorState {
   language: AvailableLanguages
@@ -41,7 +42,8 @@ export const initialState: ITranslatorState = {
   error: undefined,
   notifications: {
     copied: false,
-    noTranslationsMade: false
+    noTranslationsMade: false,
+    browserWaitTranslated: false
   },
 }
 
@@ -64,7 +66,8 @@ export const translatorSlice = createSlice({
       diffArray: action.payload,
       notifications: {
         ...state.notifications,
-        noTranslationsMade: !checkIfTranslationsHaveBeenMade(action.payload)
+        noTranslationsMade: !checkIfTranslationsHaveBeenMade(action.payload),
+        browserWaitTranslated: checkIfBrowserWaitTranslationMade(action.payload)
       }
     }),
     setError: (state, action: PayloadAction<IError>) => {
@@ -83,11 +86,18 @@ export const translatorSlice = createSlice({
         ...initialState.notifications,
         noTranslationsMade: action.payload
       }
+    }),
+    setBrowserWaitTranslated: (state, action: PayloadAction<boolean>) => ({
+      ...state,
+      notifications: {
+        ...initialState.notifications,
+        browserWaitTranslated: action.payload
+      }
     })
   },
 })
 
-export const { setLanguage, setOriginal, setModified, setDiff, setError, setCopiedNotification, setNoTranslationsMade } =
+export const { setLanguage, setOriginal, setModified, setDiff, setError, setCopiedNotification, setNoTranslationsMade, setBrowserWaitTranslated } =
   translatorSlice.actions
 
 export const selectLanguage = (state: AppState): AvailableLanguages => state.translator.language
@@ -99,9 +109,12 @@ export const selectError = (state: AppState): IError => state.translator.error
 export const selectNotifications = (state: AppState): INotifications => state.translator.notifications
 export const selectCopiedNotification = (state: AppState): boolean => state.translator.notifications.copied
 export const selectNoTranslationsMade = (state: AppState): boolean => state.translator.notifications.noTranslationsMade
+export const selectBrowserWaitTranslated = (state: AppState): boolean => state.translator.notifications.browserWaitTranslated
 
 export default translatorSlice.reducer
 
 
 export const checkIfTranslationsHaveBeenMade = (diffArray: IDiffArrayItem[]): boolean => 
   diffArray.length > 0 && diffArray.some(diff => diff.api.length > 0)
+
+export const checkIfBrowserWaitTranslationMade = (diffArray: IDiffArrayItem[]): boolean => diffArray.filter(diff => diff.api.filter(api => api.command === 'wait').length > 0).length > 0

--- a/apps/translator/components/notifications.tsx
+++ b/apps/translator/components/notifications.tsx
@@ -1,5 +1,5 @@
 import { ReactElement } from 'react'
-import { selectCopiedNotification, selectNoTranslationsMade, setCopiedNotification, setNoTranslationsMade, useAppDispatch, useAppSelector } from '../app'
+import { selectBrowserWaitTranslated, selectCopiedNotification, selectNoTranslationsMade, setBrowserWaitTranslated, setCopiedNotification, setNoTranslationsMade, useAppDispatch, useAppSelector } from '../app'
 import { Toast } from '../components'
 
 const CopiedNotification = (): ReactElement => {
@@ -42,8 +42,29 @@ const NoTranslationsMadeNotification = (): ReactElement => {
   )
 }
 
+const BrowserWaitTranslatedNotification = (): ReactElement => {
+  const showBrowserWaitTranslated = useAppSelector(selectBrowserWaitTranslated);
+  const dispatch = useAppDispatch();
+  const toggleOffBrowserWaitTranslated = () => {
+    dispatch(setBrowserWaitTranslated(false))
+  }
+  return (
+    <>
+      { showBrowserWaitTranslated ? (
+        <Toast
+          title="Potential Anti-Pattern Found"
+          message="You typically should not need to use hard code waits in your test code. Learn more about about cy.wait and retry-ability from the <a class='text-yellow-500 text-underline' href='https://on.cypress.io/wait' target='_blank'>Cypress Docs.</a>"
+          alertType="Warning"
+          hideToastAlert={toggleOffBrowserWaitTranslated}
+        />
+      ): null}
+    </>
+  )
+}
+
 const Notifications = (): ReactElement => <>
   <CopiedNotification />
   <NoTranslationsMadeNotification />
+  <BrowserWaitTranslatedNotification />
 </>
 export default Notifications


### PR DESCRIPTION
- Adds `browserWaitTranslated` flag to `INotifications` object in state
- Created `<BrowserWaitTranslatedNotification />` Component that shows and hides based upon state flag