### PR TITLE
styles(translator): remove checkmarks for navigation list items

### DIFF
--- a/apps/translator/components/translationDiff.tsx
+++ b/apps/translator/components/translationDiff.tsx
@@ -6,26 +6,36 @@ import { selectDiffApiItems, useAppSelector } from "../app";
 const TranslationDiff = (): ReactElement => {
     const diff = useAppSelector(selectDiffApiItems);
 
-    return (
-        <>
-         <h2 className="text-3xl leading-6 font-bold text-gray-900 my-4 capitalize">Details:</h2>
-        <hr />
-            <div className="flex justify-between">
-                <div>
-                    {diff.length > 0 ?  <>
-                        <ul className="list-inside list-none p-4 mb-4">
-                            {diff.map((d, i: number) => <li key={i}><a className="text-green-400 hover:text-green-500" href={d.url} rel="noreferrer" target='_blank'>{d.command}</a></li>)}
-                        </ul>
-                    </> : null}
-                </div>
-                <div>
-                    <h4 className="pt-8 font-bold">Want to dig deeper?</h4>
-                    <p>
-                        <Link href="/translations"><a className="text-green-400 hover:text-green-500"> See the full list of translations &rarr; </a></Link>
-                    </p>
-                </div>
-            </div>
-        </>
-    )
+  return (
+    <>
+      <h2 className="text-3xl leading-6 font-bold text-gray-900 my-4 capitalize">Details:</h2>
+      <hr />
+      <div className="flex justify-between">
+        <div>
+          {diff.length > 0 ? (
+            <>
+              <ul id="api" className="list-inside list-none p-4 mb-4">
+                {diff.map((d, i: number) => (
+                  <li key={i}>
+                    <a className="text-green-400 hover:text-green-500" href={d.url} rel="noreferrer" target="_blank">
+                      {d.command}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </>
+          ) : null}
+        </div>
+        <div>
+          <h4 className="pt-8 font-bold">Want to dig deeper?</h4>
+          <p>
+            <Link href="/translations">
+              <a className="text-green-400 hover:text-green-500"> See the full list of translations &rarr; </a>
+            </Link>
+          </p>
+        </div>
+      </div>
+    </>
+  )
 }
 export default TranslationDiff;

--- a/apps/translator/pages/styles.css
+++ b/apps/translator/pages/styles.css
@@ -8,7 +8,7 @@ html,
   height: 100%;
 }
 
-ul li:before {
+ul#api li:before {
   content: '✓';
   padding-right: 1rem;
 }


### PR DESCRIPTION
One of the PR's I just merged introduced this bug where the top navigation was displaying with checkmarks due to a style change in the global `styles.css`. This fixes that bug by scoping that css change to unordered lists with id's of `api` instead.