### PR TITLE
fix:update monaco react package. update colors in cypress-light theme so that selections are visible.

### DIFF
--- a/apps/translator/app/translatorSlice.ts
+++ b/apps/translator/app/translatorSlice.ts
@@ -25,10 +25,16 @@ export type AvailableLanguages = 'protractor'
 export type IColors = {
   [colorId: string]: string
 }
-const diffColors = { 'diffEditor.insertedTextBackground': '#a3e7cb', 'diffEditor.removedTextBackground': '#f8c4cd' }
-const noDiffColors = { 'diffEditor.insertedTextBackground': '#ffffff', 'diffEditor.removedTextBackground': '#ffffff' }
+const diffColors = { 'diffEditor.insertedTextBackground': '#a3e7cb70', 'diffEditor.removedTextBackground': '#f8c4cd70' }
+const noDiffColors = {
+  'diffEditor.insertedTextBackground': '#ffffff70',
+  'diffEditor.removedTextBackground': '#ffffff70',
+}
 const themeDefaultColors = {
   'editor.background': '#fff',
+  'editor.selectionBackground': '#e1e3ed',
+  'editor.selectionForeground': '#e1e3ed',
+  'editor.inactiveSelectionBackground': '#e1e3ed',
   'editor.lineHighlightBackground': '#e1e3ed',
   'scrollbarSlider.background': '#c2f1de',
   'scrollbarSlider.hoverBackground': '#a3e7cb',

--- a/apps/translator/components/translatorEditor.tsx
+++ b/apps/translator/components/translatorEditor.tsx
@@ -17,7 +17,6 @@ import {
   useAppSelector,
   selectDiffEditorThemeColors,
 } from '../app'
-import { defaultText } from '../constants'
 import { DiffToggle, CopyButton, LanguagePills } from '.'
 
 function classNames(...classes: string[]) {
@@ -96,7 +95,7 @@ const TranslateEditor = (): ReactElement => {
         <div className="px-4 py-4 sm:p-2 w-full border-solid border-2 border-gray-200 rounded">
           <DiffEditor
             language="javascript"
-            original={defaultText[selectedLanguage.toLowerCase()]}
+            original={original}
             modified={!error ? translated : null}
             keepCurrentOriginalModel={true}
             keepCurrentModifiedModel={true}
@@ -110,9 +109,14 @@ const TranslateEditor = (): ReactElement => {
               scrollbar: {
                 vertical: 'hidden',
               },
-              minimap: { enabled: false },
               renderSideBySide: !isMobile,
+              colorDecorators: false,
+              minimap: { enabled: false },
+              renderIndicators: false,
+              renderLineHighlight: "none",
+              renderOverviewRuler: false,
               readOnly: true,
+              overviewRulerLanes: 0
             }}
           />
         </div>

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@headlessui/react": "^1.4.1",
     "@heroicons/react": "^1.0.4",
-    "@monaco-editor/react": "^4.2.2",
+    "@monaco-editor/react": "^4.3.1",
     "@nrwl/next": "12.9.0",
     "@nrwl/node": "^12.9.0",
     "@reduxjs/toolkit": "^1.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1395,19 +1395,19 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@monaco-editor/loader@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@monaco-editor/loader/-/loader-1.1.1.tgz#37db648c81a86946d0febd391de00df9c28a0a3d"
-  integrity sha512-mkT4r4xDjIyOG9o9M6rJDSzEIeonwF80sYErxEvAAL4LncFVdcbNli8Qv6NDqF6nyv6sunuKkDzo4iFjxPL+uQ==
+"@monaco-editor/loader@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@monaco-editor/loader/-/loader-1.2.0.tgz#373fad69973384624e3d9b60eefd786461a76acd"
+  integrity sha512-cJVCG/T/KxXgzYnjKqyAgsKDbH9mGLjcXxN6AmwumBwa2rVFkwvGcUj1RJtD0ko4XqLqJxwqsN/Z/KURB5f1OQ==
   dependencies:
     state-local "^1.0.6"
 
-"@monaco-editor/react@^4.2.2":
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/@monaco-editor/react/-/react-4.2.2.tgz#636e5b8eb9519ef62f475f9a4a50f62ee0c493a8"
-  integrity sha512-yDDct+f/mZ946tJEXudvmMC8zXDygkELNujpJGjqJ0gS3WePZmS/IwBBsuJ8JyKQQC3Dy/+Ivg1sSpW+UvCv9g==
+"@monaco-editor/react@^4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@monaco-editor/react/-/react-4.3.1.tgz#d65bcbf174c39b6d4e7fec43d0cddda82b70a12a"
+  integrity sha512-f+0BK1PP/W5I50hHHmwf11+Ea92E5H1VZXs+wvKplWUWOfyMa1VVwqkJrXjRvbcqHL+XdIGYWhWNdi4McEvnZg==
   dependencies:
-    "@monaco-editor/loader" "^1.1.1"
+    "@monaco-editor/loader" "^1.2.0"
     prop-types "^15.7.2"
 
 "@napi-rs/triples@^1.0.3":


### PR DESCRIPTION
`diffEditor.insertedTextBackground` and `diffEditor.removedTextBackground` needed additional alpha characters to allow for transparency.

This PR also updates the Monaco React package.