### PR TITLE
workspace: create deploy translator script

### DIFF
--- a/libs/codemods/src/lib/protractor/browser.ts
+++ b/libs/codemods/src/lib/protractor/browser.ts
@@ -66,7 +66,7 @@ export function transformBrowserMethods(j: JSCodeshift, nodes: any): any {
                   ? j.identifier(node.callee.object.arguments[0].name)
                   : j.stringLiteral(
                       transformedArg && transformedArg.arguments[0]
-                        ? transformedArg.arguments[0].value
+                        ? transformedArg.arguments[0]['value']
                         : node.callee.object.arguments[0].arguments[0].value,
                     ),
               ]),

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "nx serve",
     "build": "nx build",
     "build:affected": "nx affected:build",
-    "build:translator": "nx affected --target=deploy && nx build translator --prod",
+    "build:translator": "nx build translator",
     "build:translator-vscode": "nx build translator-vscode",
     "lint:affected": "nx affected:lint",
     "test": "nx test",
@@ -15,7 +15,8 @@
     "test:translator-e2e:ci": "nx e2e translator-e2e --headless",
     "test:affected": "nx affected:test",
     "test:codemods": "nx test codemods",
-    "affected:deploy": "nx affected --target=deploy"
+    "affected:deploy": "nx affected --target=deploy",
+    "deploy:translator": "nx deploy translator"
   },
   "private": true,
   "dependencies": {

--- a/workspace.json
+++ b/workspace.json
@@ -47,7 +47,10 @@
             "outputPath": "dist/apps/translator"
           },
           "configurations": {
-            "production": {}
+            "production": {
+              "buildTarget": "translator:build:production",
+              "outputPath": "dist/apps/translator"
+            }
           }
         },
         "serve": {
@@ -82,6 +85,13 @@
           "outputs": ["{options.outputFile}"],
           "options": {
             "lintFilePatterns": ["apps/translator/**/*.{ts,tsx,js,jsx}"]
+          }
+        },
+        "deploy": {
+          "executor": "@nrwl/workspace:run-commands",
+          "outputs": [],
+          "options": {
+            "command": "nx affected --target=build --base=master --head=HEAD && nx build translator --prod && cp -R dist/apps/translator/next.config.js apps/translator/.dist"
           }
         }
       }


### PR DESCRIPTION
The current `pull-request.yml` runs `nx affected` commands against `master`. After reading this article I believe we want to run it against the most recent commit sha https://medium.com/ngconf/deploying-nx-affected-apps-from-github-actions-af28f8822ff3