### PR TITLE
fix(translator): display pill arrow when viewport is mobile

### DIFF
--- a/apps/translator/components/languagePills.tsx
+++ b/apps/translator/components/languagePills.tsx
@@ -5,8 +5,8 @@ import { selectLanguage, useAppSelector } from '../app'
 const LanguagePills = (): ReactElement => {
   const selectedLanguage = useAppSelector(selectLanguage)
   return (
-    <div className="grid grid-cols-3 gap-4">
-      <div className="col-start-2 flex justify-center">
+    <div className="grid md:grid-cols-3 gap-4 sm:grid-cols-1">
+      <div className="md:col-start-2 flex justify-center">
         <span className="px-3 py-2 rounded-full text-sm font-medium bg-red-300 text-red-800 capitalize">
           {selectedLanguage}
         </span>


### PR DESCRIPTION
The current behavior shows 3 grid columns when in a mobile viewport. This PR changes the grid columns to just 1 when `{size=sm}`. 

Closes [#DX-657](https://linear.app/cypress/issue/DX-657)