### PR TITLE
styles(translator): display menu fitems for mobile

### DIFF
--- a/apps/translator/components/navigation.tsx
+++ b/apps/translator/components/navigation.tsx
@@ -29,12 +29,15 @@ const Navigation = (): ReactElement => {
             </Link>
           </div>
 
-          <ul className="nav-list ml-10 flex items-center space-x-4" data-test="nav-list">
+          <ul
+            className="nav-list flex items-center sm:space-x-3 md:space-x-4 lg:space-x-8 leading-3 px-2"
+            data-test="nav-list"
+          >
             {migrationGuides[selectedLanguage] && (
               <li key={migrationGuides[selectedLanguage]}>
                 <a
                   href={migrationGuides[selectedLanguage].url}
-                  className="dark:bg-gray-800 hover:underline bg-transparent dark:text-white px-3 py-2 rounded-md text-xs sm:text-sm font-medium capitalize"
+                  className="dark:bg-gray-800 hover:underline bg-transparent dark:text-white py-2 rounded-md text-xs sm:text-sm font-medium capitalize"
                 >
                   {`${selectedLanguage} Migration Guide`}
                 </a>
@@ -44,7 +47,7 @@ const Navigation = (): ReactElement => {
               <li key={link.title}>
                 <a
                   href={link.url}
-                  className="dark:bg-gray-00 hover:underline bg-transparent dark:text-white px-3 py-2 rounded-md text-xs sm:text-sm font-medium"
+                  className="dark:bg-gray-00 hover:underline bg-transparent dark:text-white py-2 rounded-md text-xs sm:text-sm font-medium"
                 >
                   {link.title}
                 </a>


### PR DESCRIPTION
The current navigation for mobile is pretty _"wonky"_. This PR updates the `navigation.tsx` file to use [@responsive classes from tailwind](https://tailwindcss.com/docs/responsive-design) to display the navigation items in a more ascetically pleasing way. 

Closes [#DX 658](https://linear.app/cypress/issue/DX-658/update-header-navigation-to-work-better-on-mobile)