### PR TITLE
test(translator-e2e): add e2e tests for every supported translation

### DIFF
--- a/apps/translator-e2e/src/fixtures/assertions.json
+++ b/apps/translator-e2e/src/fixtures/assertions.json
@@ -1,0 +1,38 @@
+[
+  {
+    "protractor": "expect(by.className('thisClass').count()).toEqual(3)",
+    "cypress": "cy.get('.thisClass').its('length').should('equal', 3)"
+  },
+  {
+    "protractor": "expect(testPageObject).toBe({ id: test })",
+    "cypress": "testPageObject.should('deepEqual', { id: test })"
+  },
+  {
+    "protractor": "expect(by.css('.list').count()).toEqual(3)",
+    "cypress": "cy.get('.list').its('length').should('equal', 3)"
+  },
+  {
+    "protractor": "expect(by.css('.list').count()).not.toEqual(5)",
+    "cypress": "cy.get('.list').its('length').should('not.equal', 5)"
+  },
+  {
+    "protractor": "expect(element(by.css('.list')).isDisplayed()).toBeFalse()",
+    "cypress": "cy.get('.list').should('not.be.visible')"
+  },
+  {
+    "protractor": "expect(by.className('thisClass').isPresent()).toBeFalse()",
+    "cypress": "cy.get('.thisClass').should('not.exist')"
+  },
+  {
+    "protractor": "expect(element(by.className('test-checkbox').isSelected())).toBe(true)",
+    "cypress": "cy.get('.test-checkbox').should('be.selected')"
+  },
+  {
+    "protractor": "expect(element(by.className('input-field').isEnabled())).toBe(false)",
+    "cypress": "cy.get('.input-field').should('not.be.enabled')"
+  },
+  {
+    "protractor": "expect(element(by.id('user-name')).getText()).toBe('Joe Smith')",
+    "cypress": "cy.get('#user-name').should('have.text', 'Joe Smith')"
+  }
+]

--- a/apps/translator-e2e/src/fixtures/browser-methods.json
+++ b/apps/translator-e2e/src/fixtures/browser-methods.json
@@ -1,0 +1,66 @@
+[
+  {
+    "protractor": "browser.wait(5000)",
+    "cypress": "cy.wait(5000)"
+  },
+  {
+    "protractor": "browser.getTitle()",
+    "cypress": "cy.title()"
+  },
+  {
+    "protractor": "browser.getCurrentUrl()",
+    "cypress": "cy.location('href')"
+  },
+  {
+    "protractor": "browser.setLocation('faq')",
+    "cypress": "cy.get('#faq').scrollIntoView()"
+  },
+  {
+    "protractor": "browser.refresh()",
+    "cypress": "cy.reload()"
+  },
+  {
+    "protractor": "browser.debugger()",
+    "cypress": "cy.debug()"
+  },
+  {
+    "protractor": "browser.findElement(by.css('.list'))",
+    "cypress": "cy.get('.list')"
+  },
+  {
+    "protractor": "browser.driver.findElement(by.css('.another-list'))",
+    "cypress": "cy.get('.another-list')"
+  },
+  {
+    "protractor": "browser.restart()",
+    "cypress": ""
+  },
+  {
+    "protractor": "browser.restartSync()",
+    "cypress": ""
+  },
+  {
+    "protractor": "browser.ignoreSynchronization = true;",
+    "cypress": ""
+  },
+  {
+    "protractor": "browser.manage().timeouts().implicitlyWait(15000)",
+    "cypress": ""
+  },
+  {
+    "protractor": "browser.waitForAngular()",
+    "cypress": ""
+  },
+  {
+    "protractor": "browser.waitForAngularEnabled()",
+    "cypress": ""
+  },
+  {
+    "protractor": "browser.pause()",
+    "cypress": ""
+  },
+  {
+    "protractor": "browser.getId()",
+    "cypress": ""
+  }
+]

--- a/apps/translator-e2e/src/fixtures/example.json
+++ b/apps/translator-e2e/src/fixtures/example.json
@@ -1,4 +1,0 @@
-{
-  "name": "Using fixtures to represent data",
-  "email": "hello@cypress.io"
-}

--- a/apps/translator-e2e/src/fixtures/interactions.json
+++ b/apps/translator-e2e/src/fixtures/interactions.json
@@ -1,0 +1,26 @@
+[
+  {
+    "protractor": "element(by.className('thisClass')).sendKeys('type something')",
+    "cypress": "cy.get('.thisClass').type('type something')"
+  },
+  {
+    "protractor": "browser.actions().click(element(by.tagName('button'))).perform()",
+    "cypress": "cy.get('button').click()"
+  },
+  {
+    "protractor": "browser.actions().mouseMove(element(by.id('test-id'))).perform()",
+    "cypress": "cy.get('#test-id').scrollIntoView()"
+  },
+  {
+    "protractor": "browser.actions().doubleClick(element(by.className('list-item'))).perform()",
+    "cypress": "cy.get('.list-item').dblclick()"
+  },
+  {
+    "protractor": "element(by.id('test')).takeScreenshot()",
+    "cypress": "cy.get('#test').screenshot()"
+  },
+  {
+    "protractor": "el.takeScreenshot()",
+    "cypress": "el.screenshot()"
+  }
+]

--- a/apps/translator-e2e/src/fixtures/selectors.json
+++ b/apps/translator-e2e/src/fixtures/selectors.json
@@ -1,0 +1,94 @@
+[
+  {
+    "protractor": "by.className('thisClass')",
+    "cypress": "cy.get('.thisClass')"
+  },
+  {
+    "protractor": "by.id('my-id')",
+    "cypress": "cy.get('#my-id')"
+  },
+  {
+    "protractor": "by.css('.my-class')",
+    "cypress": "cy.get('.my-class')"
+  },
+  {
+    "protractor": "by.name('field-name')",
+    "cypress": "cy.get('input[name=\"field-name\"]')"
+  },
+  {
+    "protractor": "by.model('user.name')",
+    "cypress": "cy.get('[ng-model=\"user.name\"]')"
+  },
+  {
+    "protractor": "by.binding('value')",
+    "cypress": "cy.get('[ng-bind=\"value\"]')"
+  },
+  {
+    "protractor": "by.options('n in name')",
+    "cypress": "cy.get('[ng-options=\"n in name\"]')"
+  },
+  {
+    "protractor": "by.linkText('Google')",
+    "cypress": "cy.get('a').contains('Google')"
+  },
+  {
+    "protractor": "by.partialLinkText('Goo')",
+    "cypress": "cy.get('a').contains('Goo')"
+  },
+  {
+    "protractor": "by.cssContainingText('.my-class', 'text')",
+    "cypress": "cy.get('.my-class').contains('text')"
+  },
+  {
+    "protractor": "by.buttonText('Save')",
+    "cypress": "cy.get('button').contains('Save')"
+  },
+  {
+    "protractor": "by.partialButtonText('Save')",
+    "cypress": "cy.get('button').contains('Save')"
+  },
+  {
+    "protractor": "by.tagName('h1')",
+    "cypress": "cy.get('h1')"
+  },
+  {
+    "protractor": "by.xpath('//ul[@class=\"todo-list\"]//li')",
+    "cypress": "cy.xpath('//ul[@class=\"todo-list\"]//li')"
+  },
+  {
+    "protractor": "$('this-example')",
+    "cypress": "cy.get('this-example')"
+  },
+  {
+    "protractor": "$('example').$$('li')",
+    "cypress": "cy.get('example').find('li')"
+  },
+  {
+    "protractor": "$$('li').get(1)",
+    "cypress": "cy.get('li').eq(1)"
+  },
+  {
+    "protractor": "element(by.css('.an-element'))",
+    "cypress": "cy.get('.an-element')"
+  },
+  {
+    "protractor": "element.all(by.css('.list-items'))",
+    "cypress": "cy.get('.list-items')"
+  },
+  {
+    "protractor": "el.getAttribute('abc')",
+    "cypress": "cy.get(el).invoke('attr', 'abc')"
+  },
+  {
+    "protractor": "testElement.getDriver()",
+    "cypress": "testElement.parent()"
+  },
+  {
+    "protractor": "$('.parent').getWebElement()",
+    "cypress": "cy.get('.parent')"
+  },
+  {
+    "protractor": "element(by.css('.my-class')).getWebElement()",
+    "cypress": "cy.get('.my-class')"
+  }
+]

--- a/apps/translator/markdown/assertions.md
+++ b/apps/translator/markdown/assertions.md
@@ -2,12 +2,12 @@
 
 | Before                                                                 | After                                                 |
 | ---------------------------------------------------------------------- | ----------------------------------------------------- |
-| expect(by.className('thisClass')).count().toEqual(3)                   | cy.get('.thisClass').its('length').should('equal', 3) |
-| expect(testObject).toBe({ id: test })                                  | testObject.should('deepEqual', { id: test })          |
+| expect(by.className('thisClass').count()).toEqual(3)                   | cy.get('.thisClass').its('length').should('equal', 3) |
+| expect(testPageObject).toBe({ id: test })                              | testPageObject.should('deepEqual', { id: test })      |
 | expect(by.css('.list').count()).toEqual(3)                             | cy.get('.list').its('length').should('equal', 3)      |
 | expect(by.css('.list').count()).not.toEqual(5)                         | cy.get('.list').its('length').should('not.equal', 5)  |
 | expect(element(by.css('.list')).isDisplayed()).toBeFalse()             | cy.get('.list').should('not.be.visible')              |
-| expect(element.isPresent()).toBeFalse()                                | element.should('not.exist')                           |
-| expect(element(by.className('test-checkbox')).isSelected()).toBe(true) | cy.get('.test-checkbox').should('be.selected')        |
-| expect(element(by.className('input-field')).isEnabled()).toBe(false)   | cy.get('.input-field').should('not.be.enabled')       |
+| expect(by.className('thisClass').isPresent()).toBeFalse()              | cy.get('.thisClass').should('not.exist')              |
+| expect(element(by.className('test-checkbox').isSelected())).toBe(true) | cy.get('.test-checkbox').should('be.selected')        |
+| expect(element(by.className('input-field').isEnabled())).toBe(false)   | cy.get('.input-field').should('not.be.enabled')       |
 | expect(element(by.id('user-name')).getText()).toBe('Joe Smith')        | cy.get('#user-name').should('have.text', 'Joe Smith') |

--- a/apps/translator/markdown/browser-methods.md
+++ b/apps/translator/markdown/browser-methods.md
@@ -13,8 +13,8 @@
 | browser.restart()                                   | _Removed from file._            |
 | browser.restartSync()                               | _Removed from file._            |
 | browser.ignoreSynchronization = true                | _Removed from file._            |
-| browser.manage().timeouts().implicitlyWait(15000);  | _Removed from file._            |
-| browser.waitForAngular();                           | _Removed from file._            |
-| browser.waitForAngularEnabled();                    | _Removed from file._            |
-| browser.pause();                                    | _Removed from file._            |
-| browser.getId();                                    | _Removed from file._            |
+| browser.manage().timeouts().implicitlyWait(15000)   | _Removed from file._            |
+| browser.waitForAngular()                            | _Removed from file._            |
+| browser.waitForAngularEnabled()                     | _Removed from file._            |
+| browser.pause()                                     | _Removed from file._            |
+| browser.getId()                                     | _Removed from file._            |

--- a/apps/translator/markdown/interactions.md
+++ b/apps/translator/markdown/interactions.md
@@ -5,6 +5,6 @@
 | element(by.className('thisClass')).sendKeys('type something')               | cy.get('.thisClass').type('type something') |
 | browser.actions().click(element(by.tagName('button'))).perform()            | cy.get('button').click()                    |
 | browser.actions().mouseMove(element(by.id('test-id'))).perform()            | cy.get('#test-id').scrollIntoView()         |
-| browser.actions().doubleClick(element(by.className('list-item'))).perform() | cy.get('.listItem').dblclick()              |
+| browser.actions().doubleClick(element(by.className('list-item'))).perform() | cy.get('.list-item').dblclick()             |
 | element(by.id('test')).takeScreenshot()                                     | cy.get('#test').screenshot()                |
 | el.takeScreenshot()                                                         | el.screenshot()                             |

--- a/apps/translator/markdown/selectors.md
+++ b/apps/translator/markdown/selectors.md
@@ -21,7 +21,7 @@
 | $$('li').get(1)                              | cy.get('li').eq(1)                       |
 | element(by.css('.an-element'))               | cy.get('.an-element')                    |
 | element.all(by.css('.list-items'))           | cy.get('.list-items')                    |
-| el.getAttribute('abc' )                      | el.invoke('attr', 'abc')                 |
+| el.getAttribute('abc')                       | cy.get(el).invoke('attr', 'abc')         |
 | testElement.getDriver()                      | testElement.parent()                     |
 | $('.parent').getWebElement()                 | cy.get('.parent')                        |
 | element(by.css('.my-class')).getWebElement() | cy.get('.my-class')                      |


### PR DESCRIPTION
This PR creates an e2e tests for all translations coming back from `codemods`. Their are 3 assertion tests that are commented out that are failing. These need to be added back as a part of #39.

Closes [DX-711](https://linear.app/cypress/issue/DX-711/add-e2e-tests-for-actual-translations)