### PR TITLE
fix: update regex to exclude classes

### DIFF
--- a/libs/codemods/src/lib/utils/codemods-utils.ts
+++ b/libs/codemods/src/lib/utils/codemods-utils.ts
@@ -1,6 +1,6 @@
 export interface APIItem {
-  command: string;
-  url: string;
+  command: string
+  url: string
 }
 export interface DiffArrayItem {
   original: string
@@ -18,7 +18,7 @@ export function createDiffArray(input: string, output: string): DiffArrayItem[] 
   const diffArray: DiffArrayItem[] = []
 
   outputArray.forEach((item, index): void => {
-    const cyMatches: RegExpMatchArray = item.match(/\.(.*?)\(/g)
+    const cyMatches: RegExpMatchArray = item.match(/(?<!')\.(.*?)\(/g)
     const commands: APIItem[] = []
 
     if (cyMatches) {


### PR DESCRIPTION
I added a negative lookbehind to account for classes - which are preceded by `.` and were messing up results.