### PR TITLE
fix(migrator): remove next/router routing instances

### DIFF
--- a/apps/migrator/components/backButton.tsx
+++ b/apps/migrator/components/backButton.tsx
@@ -1,15 +1,21 @@
 import { ReactElement } from 'react'
 import { ArrowNarrowLeftIcon } from '@heroicons/react/solid'
 import Link from 'next/link'
+import { useRouter } from 'next/dist/client/router'
 
-const BackButton = (): ReactElement => (
-  <div className="-mt-px flex-1 flex">
-    <Link href="/">
-      <a className="py-8 pr-1 inline-flex items-center text-sm font-medium text-green-500 hover:text-green-700">
+const BackButton = (): ReactElement => {
+  const router = useRouter()
+  return (
+    <div className="-mt-px flex-1 flex">
+      <a
+        style={{ cursor: 'pointer' }}
+        className="py-8 pr-1 inline-flex items-center text-sm font-medium text-green-500 hover:text-green-700"
+        onClick={() => window.location.replace(window.location.href.replace('/migrations', ''))}
+      >
         <ArrowNarrowLeftIcon className="mr-3 h-5 w-5 text-gray-400" aria-hidden="true" />
         Back To Migrator
       </a>
-    </Link>
-  </div>
-)
+    </div>
+  )
+}
 export default BackButton

--- a/apps/migrator/components/navigation.tsx
+++ b/apps/migrator/components/navigation.tsx
@@ -16,16 +16,12 @@ const Navigation = (): ReactElement => {
       <nav className="flex max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-16 items-center">
         <div className="flex w-full justify-between items-center">
           <div className="flex-shrink-0 flex items-center">
-            <Link href="/">
-              <a>
-                <Image src="/logo.png" alt="Cypress Logo" width="50" height="50" />
-              </a>
-            </Link>
-            <Link href="/">
-              <a>
-                <span className="text-xl font-bold mx-2">Migrator</span>
-              </a>
-            </Link>
+            <a>
+              <Image src="/logo.png" alt="Cypress Logo" width="50" height="50" />
+            </a>
+            <a>
+              <span className="text-xl font-bold mx-2">Migrator</span>
+            </a>
           </div>
 
           <ul


### PR DESCRIPTION
After some pretty extensive exploration the `monaco-editor` is not unmounting correctly when the application routes (using `next/router`). It appears that there is also no way to manually trigger an `dismount()` of the editor using the `monaco-editor/react` package. 

Therefore the only way to solve this problem is to do a hard reload when coming back from `/migrations` => `/`. Though this is not a performant route change it is also the only instance we run into this issue and is not like a common user behavior. 