### PR TITLE
fix: update locators translating to contains to return proper syntax.

### DIFF
--- a/libs/codemods/src/lib/protractor/__testfixtures__/element-locators.output.ts
+++ b/libs/codemods/src/lib/protractor/__testfixtures__/element-locators.output.ts
@@ -50,27 +50,27 @@ describe('ElementLocators', () => {
   })
 
   it('should transform buttonText', () => {
-    cy.get('button').contains('Submit')
-    cy.get('button').contains('Submit')
-    cy.get('button').contains('Submit')
+    cy.contains('button', 'Submit')
+    cy.contains('button', 'Submit')
+    cy.contains('button', 'Submit')
   })
 
   it('should transform partialButtonText', () => {
-    cy.get('button').contains('Subm')
-    cy.get('button').contains('Subm')
-    cy.get('button').contains('Subm')
+    cy.contains('button', 'Subm')
+    cy.contains('button', 'Subm')
+    cy.contains('button', 'Subm')
   })
 
   it('should transform linkText', () => {
-    cy.get('a').contains('click')
-    cy.get('a').contains('click')
-    cy.get('a').contains('click')
+    cy.contains('a', 'click')
+    cy.contains('a', 'click')
+    cy.contains('a', 'click')
   })
 
   it('should transform partialLinkText', () => {
-    cy.get('a').contains('cli')
-    cy.get('a').contains('cli')
-    cy.get('a').contains('cli')
+    cy.contains('a', 'cli')
+    cy.contains('a', 'cli')
+    cy.contains('a', 'cli')
   })
 
   it('should transform model', () => {
@@ -93,8 +93,8 @@ describe('ElementLocators', () => {
   })
 
   it('should transform cssContainingText()', () => {
-    cy.get('.my-class').contains('text')
-    cy.get('.my-class').contains('text')
+    cy.contains('.my-class', 'text')
+    cy.contains('.my-class', 'text')
   })
 
   it('should transform options', () => {

--- a/libs/codemods/src/lib/utils/protractor-utils.ts
+++ b/libs/codemods/src/lib/utils/protractor-utils.ts
@@ -1,5 +1,4 @@
 import { ASTNode } from 'ast-types'
-import * as chalk from 'chalk'
 import { CallExpression, Collection, FileInfo, Identifier, JSCodeshift, Printable, SourceLocation } from 'jscodeshift'
 import { ProtractorSelectors, protractorSelectors } from '../protractor/constants'
 import { CodeModNode, ReplacementValues, Selector, TypedElementInExpression } from '../types'
@@ -194,14 +193,11 @@ export function replaceCyContainsSelector(
   args: any[],
 ) {
   return j.callExpression(
-    j.memberExpression(
-      j.callExpression(j.memberExpression(j.identifier('cy'), j.identifier('get'), false), [
+    j.memberExpression(j.identifier('cy'), j.identifier('contains'), false),
+    [
         propertyName === 'cssContainingText' ? args[0] : j.stringLiteral(transformedPropertyName),
-      ]),
-      j.identifier('contains'),
-      false,
-    ),
-    [propertyName === 'cssContainingText' ? args[1] : args[0]],
+        propertyName === 'cssContainingText' ? args[1] : args[0]
+      ]
   )
 }
 
@@ -210,16 +206,12 @@ export function errorMessage(message: string, expr: Printable, file: FileInfo): 
   const line = source.slice((expr.loc as SourceLocation)?.start.line - 1, (expr.loc as SourceLocation)?.end.line)[0]
   const expression = line.slice(0, (expr.loc as SourceLocation)?.end.column)
 
-  const chalkErrorMessage = chalk.bold.red
-
-  const logMessage = chalkErrorMessage(message)
-
   const fullMessage =
     '\n\n' +
     `> ${expression}\n` +
     ' '.repeat((expr.loc as SourceLocation)?.start.column + 2) +
     '^\n\n' +
-    logMessage +
+    message +
     '\n\n'
 
   return fullMessage


### PR DESCRIPTION
Fixes #112

For example, `by.partialButtonText('Subm')` now becomes `cy.contains('button', 'Subm')`