### PR TITLE
fix: add additional handling for async/await

### DIFF
--- a/libs/codemods/src/lib/protractor/__testfixtures__/example-tests.input.ts
+++ b/libs/codemods/src/lib/protractor/__testfixtures__/example-tests.input.ts
@@ -21,3 +21,11 @@ describe('Protractor Demo App', () => {
     expect(element(by.id('total')).getText()).toBe('3')
   })
 })
+
+it('should greet the named user', async function () {
+  await browser.get('http://www.angularjs.org')
+  await element(by.model('yourName')).sendKeys('Julie')
+  var greeting = element(by.binding('yourName'))
+  expect(await greeting.getText()).toEqual('Hello Julie!')
+})
+

--- a/libs/codemods/src/lib/protractor/__testfixtures__/example-tests.output.ts
+++ b/libs/codemods/src/lib/protractor/__testfixtures__/example-tests.output.ts
@@ -21,3 +21,10 @@ describe('Protractor Demo App', () => {
     cy.get('#total').should('have.text', '3')
   })
 })
+
+it('should greet the named user', function () {
+  cy.visit('http://www.angularjs.org')
+  cy.get('[ng-model="yourName"]').type('Julie')
+  var greeting = () => cy.get('[ng-bind="yourName"]')
+  greeting.should('have.text', 'Hello Julie!')
+})

--- a/libs/codemods/src/lib/protractor/__testfixtures__/example-tests.output.ts
+++ b/libs/codemods/src/lib/protractor/__testfixtures__/example-tests.output.ts
@@ -22,7 +22,7 @@ describe('Protractor Demo App', () => {
   })
 })
 
-it('should greet the named user', function () {
+it('should greet the named user', function() {
   cy.visit('http://www.angularjs.org')
   cy.get('[ng-model="yourName"]').type('Julie')
   var greeting = () => cy.get('[ng-bind="yourName"]')

--- a/libs/codemods/src/lib/protractor/index.ts
+++ b/libs/codemods/src/lib/protractor/index.ts
@@ -1,5 +1,4 @@
 import { API, ASTPath, AwaitExpression, ClassMethod, Collection, FileInfo, JSCodeshift, Transform } from 'jscodeshift'
-import path = require('path')
 import { CodeModNode, ExpressionKind, Selector } from '../types'
 import { getPropertyName, isSelector, removeByPath, sanitize } from '../utils'
 import { transformAssertions } from './assertions'

--- a/libs/codemods/src/lib/protractor/index.ts
+++ b/libs/codemods/src/lib/protractor/index.ts
@@ -23,6 +23,13 @@ const transformer: Transform = (file: FileInfo, api: API): string => {
   const classMethods: Collection<ClassMethod> = root.find(j.ClassMethod)
   // all awaits
   const awaitExpressions: Collection<AwaitExpression> = root.find(j.AwaitExpression)
+  console.log('🚀 ~ file: index.ts ~ line 26 ~ awaitExpressions', awaitExpressions)
+  console.log('🚀 ~ file: index.ts ~ line 141 ~ awaitExpressions.size()', awaitExpressions.size())
+
+  // remove await expressions
+  if (awaitExpressions.size() > 0) {
+    awaitExpressions.replaceWith((path: ASTPath<any>) => path.node.argument)
+  }
 
   // generic ast call expressions
   const callExpressions: Collection<CodeModNode> = getCallExpressions()
@@ -134,11 +141,6 @@ const transformer: Transform = (file: FileInfo, api: API): string => {
 
   // transform locators
   transformLocators(j, callExpressions)
-
-  // remove await expressions
-  if (awaitExpressions.size() > 0) {
-    awaitExpressions.replaceWith((path: ASTPath<any>) => path.node.argument)
-  }
 
   // transform non-selector expressions
   callExpressions

--- a/libs/codemods/src/lib/utils/protractor-utils.ts
+++ b/libs/codemods/src/lib/utils/protractor-utils.ts
@@ -210,16 +210,12 @@ export function errorMessage(message: string, expr: Printable, file: FileInfo): 
   const line = source.slice((expr.loc as SourceLocation)?.start.line - 1, (expr.loc as SourceLocation)?.end.line)[0]
   const expression = line.slice(0, (expr.loc as SourceLocation)?.end.column)
 
-  const chalkErrorMessage = chalk.bold.red
-
-  const logMessage = chalkErrorMessage(message)
-
   const fullMessage =
     '\n\n' +
     `> ${expression}\n` +
     ' '.repeat((expr.loc as SourceLocation)?.start.column + 2) +
     '^\n\n' +
-    logMessage +
+    message +
     '\n\n'
 
   return fullMessage


### PR DESCRIPTION
Removes async and awaits from any function.

```
it('should greet the named user', async function () {
  await browser.get('http://www.angularjs.org')
  await element(by.model('yourName')).sendKeys('Julie')
  var greeting = element(by.binding('yourName'))
  expect(await greeting.getText()).toEqual('Hello Julie!')
})
```

becomes

```
it('should greet the named user', function() {
  cy.visit('http://www.angularjs.org')
  cy.get('[ng-model="yourName"]').type('Julie')
  var greeting = () => cy.get('[ng-bind="yourName"]')
  greeting.should('have.text', 'Hello Julie!')
})
```